### PR TITLE
feat(gift-exchange): implement full CRUD APIs with DTOs and player association

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,16 +8,14 @@
 
 ## 🛠️ Changes Made
 
-<!-- 
+<!--
 List major changes clearly.
 Use bullet points or checkboxes.
 -->
 
-
 ## 🎯 Scope of Impact
 
 <!-- Briefly explain what modules, endpoints, or services are affected. -->
-
 
 ## ✅ Checklist
 
@@ -29,8 +27,6 @@ Use bullet points or checkboxes.
 ## 🧪 Tests
 
 <!-- Describe what tests were added/modified and how they validate the changes. -->
-
-
 
 ## 📸 Screenshots (if applicable)
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,12 +5,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { typeOrmConfig } from './config/typeorm.config';
 import { ConfigModule } from '@nestjs/config';
 import { PlayerModule } from './modules/player/player.module';
+import { GiftExchangeModule } from './modules/gift-exchange/gift-exchange.module';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot(typeOrmConfig),
     ConfigModule.forRoot({ isGlobal: true }), // Makes ConfigModule available everywhere
     PlayerModule,
+    GiftExchangeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -1,4 +1,5 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { GiftExchange } from 'src/modules/gift-exchange/gift-exchange.entity';
 import { Player } from 'src/modules/player/player.entity';
 
 export const typeOrmConfig: TypeOrmModuleOptions = {
@@ -10,5 +11,5 @@ export const typeOrmConfig: TypeOrmModuleOptions = {
   database: process.env.PG_DB, // Replace with your PostgreSQL database name
   autoLoadEntities: true, // Automatically load entities
   synchronize: process.env.NODE_ENV === 'development' ? true : false, // Auto-sync schema (disable in production)
-  entities: [Player],
+  entities: [Player, GiftExchange],
 };

--- a/src/modules/gift-exchange/dto/create-gift-exchange.dto.ts
+++ b/src/modules/gift-exchange/dto/create-gift-exchange.dto.ts
@@ -1,9 +1,21 @@
-import { IsNotEmpty, IsNumber } from 'class-validator';
+import { IsInt, IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateGiftExchangeDTO {
+  @IsString()
   @IsNotEmpty()
+  @MaxLength(30)
   name: string;
 
+  @IsString()
+  @IsOptional() // description is nullable in entity
+  @MaxLength(100)
+  description?: string;
+
   @IsNumber()
-  budget: number;
+  @IsOptional() // budget has default 0 in entity
+  budget?: number;
+
+  @IsInt()
+  @IsNotEmpty()
+  createdById: number; // The Player ID who created this exchange
 }

--- a/src/modules/gift-exchange/dto/update-gift-exchange.dto.ts
+++ b/src/modules/gift-exchange/dto/update-gift-exchange.dto.ts
@@ -1,0 +1,6 @@
+import { OmitType, PartialType } from '@nestjs/mapped-types';
+import { CreateGiftExchangeDTO } from './create-gift-exchange.dto';
+
+export class UpdateGiftExchangeDto extends PartialType(
+  OmitType(CreateGiftExchangeDTO, ['createdById'] as const),
+) {}

--- a/src/modules/gift-exchange/gift-exchange.controller.ts
+++ b/src/modules/gift-exchange/gift-exchange.controller.ts
@@ -1,17 +1,51 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { CreateGiftExchangeDTO } from './dto/create-gift-exchange.dto';
 import { GiftExchangeService } from './gift-exchange.service';
+import { GiftExchange } from './gift-exchange.entity';
+import { UpdateGiftExchangeDto } from './dto/update-gift-exchange.dto';
 
-@Controller('gift-exchange')
+@Controller('gift-exchanges')
 export class GiftExchangeController {
   constructor(private readonly giftExchangeService: GiftExchangeService) {}
 
   @Post()
-  async create(@Body() createGiftExchangeDTO: CreateGiftExchangeDTO): Promise<{
-    statusCode: number;
-    message: string;
-  }> {
-    await this.giftExchangeService.create(createGiftExchangeDTO);
-    return { statusCode: 123, message: '123' };
+  @HttpCode(HttpStatus.CREATED)
+  async create(@Body() createGiftExchangeDTO: CreateGiftExchangeDTO): Promise<GiftExchange> {
+    return await this.giftExchangeService.create(createGiftExchangeDTO);
+  }
+
+  @Get()
+  async findAll(): Promise<GiftExchange[]> {
+    return this.giftExchangeService.findAll();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<GiftExchange> {
+    return this.giftExchangeService.findOne(id);
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateGiftExchangeDto: UpdateGiftExchangeDto,
+  ): Promise<GiftExchange> {
+    return this.giftExchangeService.update(id, updateGiftExchangeDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.giftExchangeService.remove(id);
   }
 }

--- a/src/modules/gift-exchange/gift-exchange.entity.ts
+++ b/src/modules/gift-exchange/gift-exchange.entity.ts
@@ -2,20 +2,34 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  JoinColumn,
+  ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { Player } from '../player/player.entity';
 
 @Entity()
 export class GiftExchange {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column()
+  @Column({ length: 30, nullable: false })
   name: string;
 
-  @Column()
+  @Column({ length: 100, nullable: true })
+  description: string;
+
+  @Column('decimal', { default: 0 })
   budget: number;
+
+  @ManyToOne((_type) => Player, (player) => player.gift_exchanges, {
+    nullable: false,
+    onDelete: 'CASCADE',
+    eager: true, // optional, if you want createdBy always fetched automatically
+  })
+  @JoinColumn({ name: 'created_by' }) // The foreign key column in the table will be created_by.
+  createdBy: Player;
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/gift-exchange/gift-exchange.module.ts
+++ b/src/modules/gift-exchange/gift-exchange.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { GiftExchange } from './gift-exchange.entity';
 import { GiftExchangeController } from './gift-exchange.controller';
 import { GiftExchangeService } from './gift-exchange.service';
+import { Player } from '../player/player.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GiftExchange])],
+  imports: [TypeOrmModule.forFeature([GiftExchange, Player])],
   controllers: [GiftExchangeController],
   providers: [GiftExchangeService],
 })

--- a/src/modules/gift-exchange/gift-exchange.service.ts
+++ b/src/modules/gift-exchange/gift-exchange.service.ts
@@ -1,19 +1,53 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateGiftExchangeDTO } from './dto/create-gift-exchange.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 
 import { Repository } from 'typeorm';
 import { GiftExchange } from './gift-exchange.entity';
+import { Player } from '../player/player.entity';
 
 @Injectable()
 export class GiftExchangeService {
   constructor(
     @InjectRepository(GiftExchange)
     private readonly giftExchangeRepository: Repository<GiftExchange>,
+    @InjectRepository(Player)
+    private readonly playerRepository: Repository<Player>,
   ) {}
 
   async create(createGiftExchangeDTO: CreateGiftExchangeDTO): Promise<GiftExchange> {
-    const giftExchange = this.giftExchangeRepository.create(createGiftExchangeDTO);
+    const { createdById, ...giftExchangeData } = createGiftExchangeDTO;
+
+    // Fetch player by ID from CreateGiftExchangeDTO
+    const player = await this.playerRepository.findOneBy({ id: createdById });
+    if (!player) throw new NotFoundException('Player not found');
+
+    // Create GiftExchange entity
+    const giftExchange = this.giftExchangeRepository.create({
+      ...giftExchangeData,
+      createdBy: player,
+    });
     return this.giftExchangeRepository.save(giftExchange);
+  }
+
+  async findAll(): Promise<GiftExchange[]> {
+    return this.giftExchangeRepository.find();
+  }
+
+  async findOne(id: number): Promise<GiftExchange> {
+    const giftExchange = await this.giftExchangeRepository.findOneBy({ id });
+    if (!giftExchange) throw new NotFoundException('GiftExchange not found');
+    return giftExchange;
+  }
+
+  async update(id: number, updateDto: Partial<CreateGiftExchangeDTO>): Promise<GiftExchange> {
+    const giftExchange = await this.findOne(id);
+    Object.assign(giftExchange, updateDto);
+    return this.giftExchangeRepository.save(giftExchange);
+  }
+
+  async remove(id: number): Promise<void> {
+    const giftExchange = await this.findOne(id);
+    await this.giftExchangeRepository.remove(giftExchange);
   }
 }

--- a/src/modules/player/player.controller.ts
+++ b/src/modules/player/player.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { CreatePlayerDTO } from './dto/create-player.dto';
 import { PlayerService } from './player.service';
 import { Player } from './player.entity';
@@ -9,7 +20,7 @@ export class PlayerController {
   constructor(private readonly playerService: PlayerService) {}
 
   @Post()
-  @HttpCode(201) // explicitly sets status code
+  @HttpCode(HttpStatus.CREATED) // explicitly sets status code
   async create(@Body() createPlayerDTO: CreatePlayerDTO): Promise<Player> {
     return await this.playerService.create(createPlayerDTO);
   }
@@ -20,17 +31,21 @@ export class PlayerController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: number): Promise<Player> {
+  async findOne(@Param('id', ParseIntPipe) id: number): Promise<Player> {
     return this.playerService.findOne(id);
   }
 
   @Put(':id')
-  async update(@Param('id') id: number, @Body() dto: UpdatePlayerDto): Promise<Player> {
-    return this.playerService.update(id, dto);
+  async update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updatePlayerDto: UpdatePlayerDto,
+  ): Promise<Player> {
+    return this.playerService.update(id, updatePlayerDto);
   }
 
   @Delete(':id')
-  async remove(@Param('id') id: number): Promise<void> {
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.playerService.remove(id);
   }
 }

--- a/src/modules/player/player.entity.ts
+++ b/src/modules/player/player.entity.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
 
 @Entity()
 export class Player {
@@ -16,6 +18,9 @@ export class Player {
 
   @Column({ unique: true, nullable: false })
   email: string;
+
+  @OneToMany((_type) => GiftExchange, (gift_exchange) => gift_exchange.createdBy)
+  gift_exchanges: GiftExchange[];
 
   @CreateDateColumn()
   created_at: Date;


### PR DESCRIPTION
## 📌 Summary

This PR introduces the complete CRUD functionality for the GiftExchange entity. It includes entity definition, DTOs, service logic with player association, and controller endpoints for managing gift exchanges.

## 🧠 Context

Addresses the feature request for managing gift exchanges linked to players. Sets up the foundation to allow players to create, update, list, and delete gift exchanges.

## 🛠️ Changes Made

- Added GiftExchange entity with relation to Player (createdBy)
- Created CreateGiftExchangeDTO and UpdateGiftExchangeDTO
- Implemented service methods for create, read, update, and delete with proper validation and error handling
- Developed controller endpoints for all CRUD operations
- Ensured createdBy is validated and not updatable via API
- Standardized response structure and error handling

## 🎯 Scope of Impact

- gift-exchange module
- gift-exchange REST API endpoints (POST, GET, PUT, DELETE)
- Player entity association

## ✅ Checklist

✅ Code compiles and runs
✅ Follows coding standards and linting
✅ API response format is consistent
✅ No sensitive info in logs or commits
✅  GiftExchange Association with Player


## 📸 Screenshots (if applicable)

NA

## 📎 Related Tickets

NA