### PR TITLE
feat(exclusion-rules): complete exclusion CRUD service with proper relations and error handling

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UserModule } from './modules/user/user.module';
 import { GiftExchangeModule } from './modules/gift-exchange/gift-exchange.module';
 import { ParticipantModule } from './modules/participant/participant.module';
+import { ExclusionRuleModule } from './modules/exclusion-rule/exclusion-rule.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ParticipantModule } from './modules/participant/participant.module';
     UserModule,
     GiftExchangeModule,
     ParticipantModule,
+    ExclusionRuleModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/filters/typeorm-exception.filter.ts
+++ b/src/common/filters/typeorm-exception.filter.ts
@@ -11,7 +11,6 @@ export class TypeOrmExceptionFilter implements ExceptionFilter {
 
     // Common timestamp for all responses
     const timestamp = new Date().toISOString();
-
     // Default to 500 Internal Server Error
     switch ((exception as any).code) {
       case '23505': // Unique constraint violation

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -1,4 +1,5 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ExclusionRule } from 'src/modules/exclusion-rule/exclusion-rule.entity';
 import { GiftExchange } from 'src/modules/gift-exchange/gift-exchange.entity';
 import { Participant } from 'src/modules/participant/participant.entity';
 import { User } from 'src/modules/user/user.entity';
@@ -12,5 +13,5 @@ export const typeOrmConfig: TypeOrmModuleOptions = {
   database: process.env.PG_DB, // Replace with your PostgreSQL database name
   autoLoadEntities: true, // Automatically load entities
   synchronize: process.env.NODE_ENV === 'development' ? true : false, // Auto-sync schema (disable in production)
-  entities: [User, GiftExchange, Participant],
+  entities: [User, GiftExchange, Participant, ExclusionRule],
 };

--- a/src/modules/exclusion-rule/dto/create-exclusion-rule.dto.ts
+++ b/src/modules/exclusion-rule/dto/create-exclusion-rule.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsNotEmpty } from 'class-validator';
+
+export class CreateExclusionRuleDTO {
+  @IsInt()
+  @IsNotEmpty()
+  gift_exchange_id: number;
+
+  @IsInt()
+  @IsNotEmpty()
+  participant_id: number;
+
+  @IsInt()
+  @IsNotEmpty()
+  excluded_participant_id: number;
+}

--- a/src/modules/exclusion-rule/exclusion-rule.controller.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Post, Body, Get, Delete, Param, ParseIntPipe } from '@nestjs/common';
+import { ExclusionRuleService } from './exclusion-rule.service';
+import { CreateExclusionRuleDTO } from './dto/create-exclusion-rule.dto';
+
+@Controller('exclusion-rules')
+export class ExclusionRuleController {
+  constructor(private readonly exclusionRuleService: ExclusionRuleService) {}
+
+  @Post()
+  create(@Body() createExclusionRuleDTO: CreateExclusionRuleDTO) {
+    return this.exclusionRuleService.create(createExclusionRuleDTO);
+  }
+
+  @Get()
+  findAll() {
+    return this.exclusionRuleService.findAll();
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseIntPipe) id: number) {
+    return this.exclusionRuleService.remove(id);
+  }
+}

--- a/src/modules/exclusion-rule/exclusion-rule.entity.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.entity.ts
@@ -5,6 +5,7 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
   UpdateDateColumn,
 } from 'typeorm';
 import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
@@ -12,6 +13,9 @@ import { Participant } from '../participant/participant.entity';
 
 @Check(`"participant_id" <> "excluded_participant_id"`)
 // Make sure that participant_id != excluded_participant_id
+@Unique(['participant', 'excluded_participant', 'gift_exchange'])
+// Make sure that same exclusion rule is not replated
+
 @Entity()
 export class ExclusionRule {
   @PrimaryGeneratedColumn()

--- a/src/modules/exclusion-rule/exclusion-rule.entity.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Check,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
+import { Participant } from '../participant/participant.entity';
+
+@Check(`"participant_id" <> "excluded_participant_id"`)
+// Make sure that participant_id != excluded_participant_id
+@Entity()
+export class ExclusionRule {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne((_type) => GiftExchange, (gift_exchange) => gift_exchange.exclusion_rules, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'gift_exchange_id' })
+  gift_exchange: GiftExchange;
+
+  @ManyToOne((_type) => Participant, (participant) => participant.exclusion_rules, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'participant_id' })
+  participant: Participant;
+
+  @ManyToOne((_type) => Participant, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'excluded_participant_id' })
+  excluded_participant: Participant;
+
+  @CreateDateColumn()
+  created_at: Date;
+
+  @UpdateDateColumn()
+  modified_at: Date;
+}

--- a/src/modules/exclusion-rule/exclusion-rule.module.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
+import { ExclusionRuleService } from './exclusion-rule.service';
+import { ExclusionRuleController } from './exclusion-rule.controller';
+import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
+import { Participant } from '../participant/participant.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([GiftExchange, Participant, ExclusionRule])],
+  controllers: [ExclusionRuleController],
+  providers: [ExclusionRuleService],
+})
+export class ExclusionRuleModule {}

--- a/src/modules/exclusion-rule/exclusion-rule.service.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.service.ts
@@ -4,7 +4,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
 import { Participant } from '../participant/participant.entity';
 import { CreateExclusionRuleDTO } from './dto/create-exclusion-rule.dto';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 export class ExclusionRuleService {
   constructor(
@@ -21,7 +21,7 @@ export class ExclusionRuleService {
   async create(createExclusionRuleDto: CreateExclusionRuleDTO): Promise<ExclusionRule> {
     const { gift_exchange_id, participant_id, excluded_participant_id } = createExclusionRuleDto;
     if (participant_id === excluded_participant_id) {
-      throw new Error('A participant cannot exclude themselves.');
+      throw new BadRequestException('A participant cannot exclude themselves.');
     }
 
     const giftExchange = await this.giftExchangeRepo.findOneBy({ id: gift_exchange_id });

--- a/src/modules/exclusion-rule/exclusion-rule.service.ts
+++ b/src/modules/exclusion-rule/exclusion-rule.service.ts
@@ -1,0 +1,58 @@
+import { Repository } from 'typeorm';
+import { ExclusionRule } from './exclusion-rule.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
+import { Participant } from '../participant/participant.entity';
+import { CreateExclusionRuleDTO } from './dto/create-exclusion-rule.dto';
+import { NotFoundException } from '@nestjs/common';
+
+export class ExclusionRuleService {
+  constructor(
+    @InjectRepository(ExclusionRule)
+    private exclusionRuleRepo: Repository<ExclusionRule>,
+
+    @InjectRepository(GiftExchange)
+    private giftExchangeRepo: Repository<GiftExchange>,
+
+    @InjectRepository(Participant)
+    private participantRepo: Repository<Participant>,
+  ) {}
+
+  async create(createExclusionRuleDto: CreateExclusionRuleDTO): Promise<ExclusionRule> {
+    const { gift_exchange_id, participant_id, excluded_participant_id } = createExclusionRuleDto;
+    if (participant_id === excluded_participant_id) {
+      throw new Error('A participant cannot exclude themselves.');
+    }
+
+    const giftExchange = await this.giftExchangeRepo.findOneBy({ id: gift_exchange_id });
+    if (!giftExchange) throw new NotFoundException('Gift Exchange not found');
+
+    const participant = await this.participantRepo.findOneBy({ id: participant_id });
+    const excludedParticipant = await this.participantRepo.findOneBy({
+      id: excluded_participant_id,
+    });
+
+    if (!participant || !excludedParticipant) {
+      throw new NotFoundException('Participant(s) not found');
+    }
+
+    const exclusionRule = this.exclusionRuleRepo.create({
+      gift_exchange: giftExchange,
+      participant,
+      excluded_participant: excludedParticipant,
+    });
+
+    return this.exclusionRuleRepo.save(exclusionRule);
+  }
+
+  async findAll(): Promise<ExclusionRule[]> {
+    return this.exclusionRuleRepo.find({
+      relations: ['gift_exchange', 'participant', 'excluded_participant'],
+    });
+  }
+
+  async remove(id: number): Promise<void> {
+    const result = await this.exclusionRuleRepo.delete(id);
+    if (result.affected === 0) throw new NotFoundException('Exclusion rule not found');
+  }
+}

--- a/src/modules/gift-exchange/gift-exchange.entity.ts
+++ b/src/modules/gift-exchange/gift-exchange.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { User } from '../user/user.entity';
 import { Participant } from '../participant/participant.entity';
+import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
 
 @Entity()
 export class GiftExchange {
@@ -25,9 +26,6 @@ export class GiftExchange {
   @Column('decimal', { default: 0 })
   budget: number;
 
-  @OneToMany((_type) => Participant, (participant) => participant.giftExchange)
-  participants: Participant[];
-
   @ManyToOne((_type) => User, (user) => user.gift_exchanges, {
     nullable: false,
     onDelete: 'CASCADE',
@@ -35,6 +33,12 @@ export class GiftExchange {
   })
   @JoinColumn({ name: 'created_by' }) // The foreign key column in the table will be created_by.
   createdBy: User;
+
+  @OneToMany((_type) => Participant, (participant) => participant.gift_exchange)
+  participants: Participant[];
+
+  @OneToMany((_type) => ExclusionRule, (exclusion_rule) => exclusion_rule.gift_exchange)
+  exclusion_rules: ExclusionRule[]; // Each exchange can have multiple exclusions
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/gift-exchange/gift-exchange.module.ts
+++ b/src/modules/gift-exchange/gift-exchange.module.ts
@@ -4,9 +4,10 @@ import { GiftExchange } from './gift-exchange.entity';
 import { GiftExchangeController } from './gift-exchange.controller';
 import { GiftExchangeService } from './gift-exchange.service';
 import { User } from '../user/user.entity';
+import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([GiftExchange, User])],
+  imports: [TypeOrmModule.forFeature([GiftExchange, User, ExclusionRule])],
   controllers: [GiftExchangeController],
   providers: [GiftExchangeService],
 })

--- a/src/modules/participant/participant.entity.ts
+++ b/src/modules/participant/participant.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
   UpdateDateColumn,
 } from 'typeorm';
 import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
@@ -13,6 +14,7 @@ import { User } from '../user/user.entity';
 import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
 
 @Entity()
+@Unique(['user', 'gift_exchange']) // Ensures that a user can only participate once in a particular gift exchange
 export class Participant {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/modules/participant/participant.entity.ts
+++ b/src/modules/participant/participant.entity.ts
@@ -4,11 +4,13 @@ import {
   Entity,
   JoinColumn,
   ManyToOne,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
 import { User } from '../user/user.entity';
+import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
 
 @Entity()
 export class Participant {
@@ -20,14 +22,17 @@ export class Participant {
     onDelete: 'CASCADE', // If the gift-exchange is deleted, cascade delete the participant.
   })
   @JoinColumn({ name: 'gift_exchange_id' })
-  giftExchange: GiftExchange;
+  gift_exchange: GiftExchange;
 
-  @ManyToOne(() => User, (user) => user.participants, {
+  @ManyToOne((_type) => User, (user) => user.participants, {
     nullable: false, // Each participants must be a user
     onDelete: 'CASCADE', // If the user is deleted, cascade delete the participant
   })
   @JoinColumn({ name: 'user_id' })
   user?: User;
+
+  @OneToMany((_type) => ExclusionRule, (exclusion_rule) => exclusion_rule.participant)
+  exclusion_rules: ExclusionRule[]; // Each participant can have multiple exclusion rules
 
   @CreateDateColumn()
   created_at: Date;

--- a/src/modules/participant/participant.module.ts
+++ b/src/modules/participant/participant.module.ts
@@ -5,9 +5,10 @@ import { ParticipantService } from './participant.service';
 import { ParticipantController } from './participant.controller';
 import { GiftExchange } from '../gift-exchange/gift-exchange.entity';
 import { User } from '../user/user.entity';
+import { ExclusionRule } from '../exclusion-rule/exclusion-rule.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Participant, GiftExchange, User])],
+  imports: [TypeOrmModule.forFeature([Participant, GiftExchange, User, ExclusionRule])],
   controllers: [ParticipantController],
   providers: [ParticipantService],
 })

--- a/src/modules/participant/participant.service.ts
+++ b/src/modules/participant/participant.service.ts
@@ -29,20 +29,20 @@ export class ParticipantService {
       throw new NotFoundException('Either Gift exchange or Participant not found');
     }
     const participant = this.participantRepository.create({
-      giftExchange: exchange,
+      gift_exchange: exchange,
       user: user,
     });
     return this.participantRepository.save(participant);
   }
 
   async findAll(): Promise<Participant[]> {
-    return this.participantRepository.find({ relations: ['giftExchange', 'user'] });
+    return this.participantRepository.find({ relations: ['gift_exchange', 'user'] });
   }
 
   async findOne(id: number): Promise<Participant> {
     const participant = await this.participantRepository.findOne({
       where: { id },
-      relations: ['giftExchange', 'user'],
+      relations: ['gift_exchange', 'user'],
     });
     if (!participant) throw new NotFoundException('Participant not found');
     return participant;


### PR DESCRIPTION
## 📌 Summary

Added ExclusionRule entity to manage participant-level exclusions within a Gift Exchange. Ensures that a participant cannot be assigned to excluded participants during the matching process.

## 🧠 Context

Participants in a Gift Exchange may want to exclude certain participants. These exclusions must be stored and enforced during the random assignment logic. This PR adds a dedicated table to manage such exclusion rules.


## 🛠️ Changes Made

- Created new ExclusionRule entity
- Contains gift_exchange_id, participant_id, and excluded_participant_id
- Enforced uniqueness to prevent duplicate exclusion rules
- Added DB check to ensure a participant cannot exclude themselves
- Updated GiftExchange and Participant entities to establish relationships with ExclusionRule
- Ensured snake_case naming for all DB columns
- Created controller, service, and DTOs for managing ExclusionRule CRUD operations

## 🎯 Scope of Impact

- New DB table: exclusion_rule
- Affects Gift Exchange and Participant entity relations
- Adds new API endpoints for managing exclusions between participants

## ✅ Checklist

✅ Code compiles and runs
✅ Follows coding standards and linting
✅ API response format is consistent
✅ No sensitive info in logs or commits

## 📸 Screenshots (if applicable)
NA

## 📎 Related Tickets
NA